### PR TITLE
Add basic route tests

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,19 +1,18 @@
+import os
 import pytest
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 
 @pytest.fixture(scope="session")
-def app() -> FastAPI:
-    application = FastAPI()
+def app():
+    """Create the real FastAPI application using an in-memory DB."""
+    os.environ["DATABASE_URL"] = "sqlite:///./test.db"
+    from fluxocaixa import create_app
 
-    @application.get("/")
-    def read_root() -> dict[str, str]:
-        return {"message": "ok"}
-
+    application = create_app()
     return application
 
 
 @pytest.fixture()
-def client(app: FastAPI) -> TestClient:
+def client(app) -> TestClient:
     return TestClient(app)

--- a/src/tests/unit/test_pagamentos.py
+++ b/src/tests/unit/test_pagamentos.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def test_pagamentos_page(client):
+    response = client.get('/pagamentos')
+    assert response.status_code == 200
+    assert 'Pagamentos' in response.text
+
+
+def test_relatorios_page(client):
+    response = client.get('/relatorios')
+    assert response.status_code == 200
+    assert 'Relatórios de Fluxo de Caixa' in response.text

--- a/src/tests/unit/test_placeholder.py
+++ b/src/tests/unit/test_placeholder.py
@@ -1,7 +1,4 @@
-from fastapi import FastAPI
-
-
-def test_root(client):
+def test_index_page(client):
     response = client.get("/")
     assert response.status_code == 200
-    assert response.json() == {"message": "ok"}
+    assert "Módulos do Sistema" in response.text

--- a/src/tests/unit/test_saldos.py
+++ b/src/tests/unit/test_saldos.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+def test_saldos_page(client):
+    response = client.get('/saldos')
+    assert response.status_code == 200
+    assert 'Lançamentos' in response.text


### PR DESCRIPTION
## Summary
- replace test fixtures to use real app
- test index, saldos, pagamentos and relatorios routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888b920aac8832a93da50e7582f25a2