### PR TITLE
Add integration tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ gunicorn==21.2.0
 pydantic>=2.6,<3
 openpyxl==3.1.2
 httpx==0.27.0
+pytest==8.4.1

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -2,15 +2,17 @@ import os
 import pytest
 from fastapi.testclient import TestClient
 
+# Configure a shared in-memory SQLite database for all tests
+os.environ["DATABASE_URL"] = (
+    "sqlite:///file:memdb1?mode=memory&cache=shared&check_same_thread=False&uri=true"
+)
+from fluxocaixa import create_app
+
 
 @pytest.fixture(scope="session")
 def app():
-    """Create the real FastAPI application using an in-memory DB."""
-    os.environ["DATABASE_URL"] = "sqlite:///file::memory:?cache=shared&check_same_thread=False"
-    from fluxocaixa import create_app
-
-    application = create_app()
-    return application
+    """Create the real FastAPI application."""
+    return create_app()
 
 
 @pytest.fixture()

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -1,19 +1,18 @@
+import os
 import pytest
-from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 
 @pytest.fixture(scope="session")
-def app() -> FastAPI:
-    application = FastAPI()
+def app():
+    """Create the real FastAPI application using an in-memory DB."""
+    os.environ["DATABASE_URL"] = "sqlite:///file::memory:?cache=shared&check_same_thread=False"
+    from fluxocaixa import create_app
 
-    @application.get("/")
-    def read_root() -> dict[str, str]:
-        return {"message": "ok"}
-
+    application = create_app()
     return application
 
 
 @pytest.fixture()
-def client(app: FastAPI) -> TestClient:
+def client(app) -> TestClient:
     return TestClient(app)

--- a/src/tests/integration/test_flows.py
+++ b/src/tests/integration/test_flows.py
@@ -1,8 +1,15 @@
 from fastapi.testclient import TestClient
-from fluxocaixa.models import db, Lancamento, Pagamento, Qualificador, TipoLancamento, OrigemLancamento, Orgao
 
 
 def test_add_lancamento_flow(client: TestClient):
+    from fluxocaixa.models import (
+        db,
+        Lancamento,
+        Qualificador,
+        TipoLancamento,
+        OrigemLancamento,
+    )
+
     # initial count
     initial = db.session.query(Lancamento).count()
     qual = Qualificador.query.first()
@@ -17,13 +24,15 @@ def test_add_lancamento_flow(client: TestClient):
             'cod_tipo_lancamento': tipo.cod_tipo_lancamento,
             'cod_origem_lancamento': origem.cod_origem_lancamento,
         },
-        allow_redirects=False,
+        follow_redirects=False,
     )
     assert resp.status_code == 303
     assert db.session.query(Lancamento).count() == initial + 1
 
 
 def test_add_pagamento_flow(client: TestClient):
+    from fluxocaixa.models import db, Pagamento, Orgao
+
     initial = db.session.query(Pagamento).count()
     orgao = Orgao.query.first()
     resp = client.post(
@@ -34,7 +43,7 @@ def test_add_pagamento_flow(client: TestClient):
             'val_pagamento': '200.00',
             'dsc_pagamento': 'Teste de pagamento',
         },
-        allow_redirects=False,
+        follow_redirects=False,
     )
     assert resp.status_code == 303
     assert db.session.query(Pagamento).count() == initial + 1

--- a/src/tests/integration/test_flows.py
+++ b/src/tests/integration/test_flows.py
@@ -1,0 +1,46 @@
+from fastapi.testclient import TestClient
+from fluxocaixa.models import db, Lancamento, Pagamento, Qualificador, TipoLancamento, OrigemLancamento, Orgao
+
+
+def test_add_lancamento_flow(client: TestClient):
+    # initial count
+    initial = db.session.query(Lancamento).count()
+    qual = Qualificador.query.first()
+    tipo = TipoLancamento.query.first()
+    origem = OrigemLancamento.query.first()
+    resp = client.post(
+        '/saldos/add',
+        data={
+            'dat_lancamento': '2025-01-01',
+            'seq_qualificador': qual.seq_qualificador,
+            'val_lancamento': '123.45',
+            'cod_tipo_lancamento': tipo.cod_tipo_lancamento,
+            'cod_origem_lancamento': origem.cod_origem_lancamento,
+        },
+        allow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert db.session.query(Lancamento).count() == initial + 1
+
+
+def test_add_pagamento_flow(client: TestClient):
+    initial = db.session.query(Pagamento).count()
+    orgao = Orgao.query.first()
+    resp = client.post(
+        '/pagamentos/add',
+        data={
+            'dat_pagamento': '2025-02-01',
+            'cod_orgao': orgao.cod_orgao,
+            'val_pagamento': '200.00',
+            'dsc_pagamento': 'Teste de pagamento',
+        },
+        allow_redirects=False,
+    )
+    assert resp.status_code == 303
+    assert db.session.query(Pagamento).count() == initial + 1
+
+
+def test_relatorio_resumo_page(client: TestClient):
+    resp = client.get('/relatorios/resumo')
+    assert resp.status_code == 200
+    assert 'Resumo do Fluxo de Caixa' in resp.text

--- a/src/tests/unit/test_pagamentos.py
+++ b/src/tests/unit/test_pagamentos.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def test_pagamentos_page(client):
+    response = client.get('/pagamentos')
+    assert response.status_code == 200
+    assert 'Pagamentos' in response.text
+
+
+def test_relatorios_page(client):
+    response = client.get('/relatorios')
+    assert response.status_code == 200
+    assert 'Relatórios de Fluxo de Caixa' in response.text

--- a/src/tests/unit/test_pagamentos.py
+++ b/src/tests/unit/test_pagamentos.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_pagamentos_page(client):
     response = client.get('/pagamentos')
     assert response.status_code == 200

--- a/src/tests/unit/test_placeholder.py
+++ b/src/tests/unit/test_placeholder.py
@@ -1,7 +1,4 @@
-from fastapi import FastAPI
-
-
-def test_root(client):
+def test_index_page(client):
     response = client.get("/")
     assert response.status_code == 200
-    assert response.json() == {"message": "ok"}
+    assert "Módulos do Sistema" in response.text

--- a/src/tests/unit/test_saldos.py
+++ b/src/tests/unit/test_saldos.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 def test_saldos_page(client):
     response = client.get('/saldos')
     assert response.status_code == 200

--- a/src/tests/unit/test_saldos.py
+++ b/src/tests/unit/test_saldos.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+def test_saldos_page(client):
+    response = client.get('/saldos')
+    assert response.status_code == 200
+    assert 'Lançamentos' in response.text


### PR DESCRIPTION
## Summary
- add TestClient-based integration tests covering database inserts
- verify the cash flow summary page responds correctly

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888b920aac8832a93da50e7582f25a2