### PR TITLE
feat: centralize route exception handling

### DIFF
--- a/src/fluxocaixa/web/__init__.py
+++ b/src/fluxocaixa/web/__init__.py
@@ -1,17 +1,17 @@
-from fastapi import APIRouter
 from fastapi.templating import Jinja2Templates
 import os
 
 from ..utils import format_currency
 
 from ..config import BASE_DIR
+from .safe_router import SafeAPIRouter, handle_exceptions
 
 # Shared router and templates object used by the route modules
-router = APIRouter()
+router = SafeAPIRouter()
 templates = Jinja2Templates(directory=os.path.join(BASE_DIR, 'templates'))
 templates.env.filters['format_currency'] = format_currency
 
 # Import routes so they register themselves with the router
 from . import base, pagamentos, mapeamentos, relatorios, alertas  # noqa: E402,F401
 
-__all__ = ['router', 'templates']
+__all__ = ['router', 'templates', 'handle_exceptions']

--- a/src/fluxocaixa/web/alertas.py
+++ b/src/fluxocaixa/web/alertas.py
@@ -1,7 +1,7 @@
 from fastapi import Request
 from fastapi.responses import RedirectResponse
 
-from . import router, templates
+from . import router, templates, handle_exceptions
 from ..domain import AlertaCreate, AlertaUpdate
 from ..services import (
     list_alertas,
@@ -12,16 +12,19 @@ from ..services import (
 from ..repositories import AlertaRepository
 
 @router.get('/alertas')
+@handle_exceptions
 async def alertas(request: Request):
     regras, _ = list_alertas()
     return templates.TemplateResponse('alertas.html', {'request': request, 'regras': regras})
 
 @router.get('/alertas/novo')
+@handle_exceptions
 async def novo_alerta(request: Request):
     _, qualificadores = list_alertas()
     return templates.TemplateResponse('alertas_novo.html', {'request': request, 'qualificadores': qualificadores})
 
 @router.post('/alertas/novo')
+@handle_exceptions
 async def criar_alerta(request: Request):
     form = await request.form()
     data = AlertaCreate(
@@ -39,6 +42,7 @@ async def criar_alerta(request: Request):
 
 
 @router.get('/alertas/edit/{seq_alerta}')
+@handle_exceptions
 async def edit_alerta(request: Request, seq_alerta: int):
     repo = AlertaRepository()
     alerta = repo.get(seq_alerta)
@@ -50,6 +54,7 @@ async def edit_alerta(request: Request, seq_alerta: int):
 
 
 @router.post('/alertas/edit/{seq_alerta}', name='update_alerta')
+@handle_exceptions
 async def update_alerta_route(request: Request, seq_alerta: int):
     form = await request.form()
     data = AlertaUpdate(
@@ -67,6 +72,7 @@ async def update_alerta_route(request: Request, seq_alerta: int):
 
 
 @router.post('/alertas/delete/{seq_alerta}', name='delete_alerta')
+@handle_exceptions
 async def delete_alerta_route(request: Request, seq_alerta: int):
     delete_alerta(seq_alerta)
     return RedirectResponse(request.url_for('alertas'), status_code=303)

--- a/src/fluxocaixa/web/mapeamentos.py
+++ b/src/fluxocaixa/web/mapeamentos.py
@@ -1,7 +1,7 @@
 from fastapi import Request
 from fastapi.responses import RedirectResponse
 
-from . import router, templates
+from . import router, templates, handle_exceptions
 from ..domain import MapeamentoCreate
 from ..services import (
     list_mapeamentos,
@@ -13,6 +13,7 @@ from ..repositories import MapeamentoRepository
 
 
 @router.get('/mapeamentos')
+@handle_exceptions
 async def mapeamentos(request: Request):
     status_filter = request.query_params.get('status', 'A')
     tipo_filter = request.query_params.get('tipo', '')
@@ -37,6 +38,7 @@ async def mapeamentos(request: Request):
 
 
 @router.post('/mapeamentos/add')
+@handle_exceptions
 async def add_mapeamento(request: Request):
     form = await request.form()
     data = MapeamentoCreate(
@@ -49,6 +51,7 @@ async def add_mapeamento(request: Request):
 
 
 @router.post('/mapeamentos/edit/{seq_mapeamento}')
+@handle_exceptions
 async def edit_mapeamento(request: Request, seq_mapeamento: int):
     form = await request.form()
     data = MapeamentoCreate(
@@ -61,12 +64,14 @@ async def edit_mapeamento(request: Request, seq_mapeamento: int):
 
 
 @router.post('/mapeamentos/delete/{seq_mapeamento}', name='delete_mapeamento')
+@handle_exceptions
 async def delete_mapeamento_route(request: Request, seq_mapeamento: int):
     delete_mapeamento(seq_mapeamento)
     return RedirectResponse(request.url_for('mapeamentos'), status_code=303)
 
 
 @router.get('/mapeamentos/get/{seq_mapeamento}')
+@handle_exceptions
 async def get_mapeamento(seq_mapeamento: int):
     repo = MapeamentoRepository()
     mapeamento = repo.get(seq_mapeamento)

--- a/src/fluxocaixa/web/pagamentos.py
+++ b/src/fluxocaixa/web/pagamentos.py
@@ -2,12 +2,13 @@ from datetime import date
 from fastapi import Request
 from fastapi.responses import RedirectResponse
 
-from . import router, templates
+from . import router, templates, handle_exceptions
 from ..domain import PagamentoCreate
 from ..services import list_pagamentos, create_pagamento
 
 
 @router.get('/pagamentos')
+@handle_exceptions
 async def pagamentos(request: Request):
     pagamentos, orgaos = list_pagamentos()
     return templates.TemplateResponse(
@@ -17,6 +18,7 @@ async def pagamentos(request: Request):
 
 
 @router.post('/pagamentos/add')
+@handle_exceptions
 async def add_pagamento(request: Request):
     form = await request.form()
     data = PagamentoCreate(

--- a/src/fluxocaixa/web/relatorios.py
+++ b/src/fluxocaixa/web/relatorios.py
@@ -4,7 +4,7 @@ from datetime import date
 from fastapi import Request
 from fastapi.responses import JSONResponse
 from sqlalchemy import func, extract, or_
-from . import router, templates
+from . import router, templates, handle_exceptions
 from ..models import (
     db,
     TipoLancamento,
@@ -51,12 +51,14 @@ MONTH_NAME_PT = {
 
 
 @router.get("/relatorios")
+@handle_exceptions
 async def relatorios(request: Request):
     return templates.TemplateResponse("relatorios.html", {"request": request})
 
 
 @router.get("/relatorios/resumo")
 @router.post("/relatorios/resumo")
+@handle_exceptions
 async def relatorio_resumo(request: Request):
     lancamento_years = (
         db.session.query(extract("year", Lancamento.dat_lancamento)).distinct().all()
@@ -244,6 +246,7 @@ async def relatorio_resumo(request: Request):
 
 @router.get("/relatorios/indicadores")
 @router.post("/relatorios/indicadores")
+@handle_exceptions
 async def relatorio_indicadores(request: Request):
     lancamento_years = (
         db.session.query(extract("year", Lancamento.dat_lancamento)).distinct().all()
@@ -404,6 +407,7 @@ async def relatorio_indicadores(request: Request):
 
 @router.get("/relatorios/analise-comparativa")
 @router.post("/relatorios/analise-comparativa")
+@handle_exceptions
 async def relatorio_analise_comparativa(request: Request):
     form = await request.form() if request.method == "POST" else {}
     tipo_analise = form.get("tipo_analise", "receitas")
@@ -517,6 +521,7 @@ async def relatorio_analise_comparativa(request: Request):
 
 @router.get("/relatorios/dfc")
 @router.post("/relatorios/dfc")
+@handle_exceptions
 async def relatorio_dfc(request: Request):
     """Tela de Análise de Fluxo (DFC) com dados reais ou projetados."""
 
@@ -700,6 +705,7 @@ async def relatorio_dfc(request: Request):
 
 
 @router.get("/relatorios/dfc/eventos")
+@handle_exceptions
 async def dfc_eventos(request: Request):
     """Retorna os eventos (lançamentos) para um qualificador e coluna."""
 

--- a/src/fluxocaixa/web/safe_router.py
+++ b/src/fluxocaixa/web/safe_router.py
@@ -1,0 +1,47 @@
+"""Utilities for safer route registration with automatic exception handling."""
+
+import inspect
+import logging
+from functools import wraps
+
+from fastapi import APIRouter, HTTPException
+
+logger = logging.getLogger(__name__)
+
+
+def handle_exceptions(func):
+    """Wrap endpoint functions to provide basic exception handling."""
+
+    if inspect.iscoroutinefunction(func):
+
+        @wraps(func)
+        async def async_wrapper(*args, **kwargs):
+            try:
+                return await func(*args, **kwargs)
+            except HTTPException:
+                raise
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.exception("Unhandled exception in endpoint: %s", exc)
+                raise HTTPException(status_code=500, detail="Internal server error")
+
+        return async_wrapper
+
+    @wraps(func)
+    def sync_wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except HTTPException:
+            raise
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("Unhandled exception in endpoint: %s", exc)
+            raise HTTPException(status_code=500, detail="Internal server error")
+
+    return sync_wrapper
+
+
+class SafeAPIRouter(APIRouter):
+    """APIRouter that automatically wraps endpoints with exception handling."""
+
+    def add_api_route(self, path: str, endpoint, **kwargs):  # type: ignore[override]
+        endpoint = handle_exceptions(endpoint)
+        return super().add_api_route(path, endpoint, **kwargs)


### PR DESCRIPTION
## Summary
- introduce `handle_exceptions` decorator and expose it through `SafeAPIRouter`
- apply `handle_exceptions` across all route handlers for consistent try/except protection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688aa83b1728832a9d3f4cf5cbfa3356