### PR TITLE
feat: add previsao x realizado report

### DIFF
--- a/src/fluxocaixa/models/cenario.py
+++ b/src/fluxocaixa/models/cenario.py
@@ -20,6 +20,9 @@ class Cenario(Base):
     dat_criacao = Column(Date, default=date.today, nullable=False)
     ind_status = Column(String(1), default='A', nullable=False)
     dat_inclusao = Column(Date, default=date.today, nullable=False)
+    cod_pessoa_inclusao = Column(Integer, nullable=False)
+    dat_alteracao = Column(Date)
+    cod_pessoa_alteracao = Column(Integer)
 
 class CenarioAjusteMensal(Base):
     __tablename__ = 'flc_cenario_ajuste_mensal'

--- a/src/fluxocaixa/services/seed.py
+++ b/src/fluxocaixa/services/seed.py
@@ -528,7 +528,11 @@ def seed_data(session=None):
 
     # Cenário de exemplo com ajustes mensais
     if not Cenario.query.first():
-        cenario_base = Cenario(nom_cenario='Base', dsc_cenario='Cenário inicial')
+        cenario_base = Cenario(
+            nom_cenario='Base',
+            dsc_cenario='Cenário inicial',
+            cod_pessoa_inclusao=1,
+        )
         session.add(cenario_base)
         session.flush()
         icms_qual = encontrar_qualificador('ICMS')

--- a/templates/rel_previsao_realizado.html
+++ b/templates/rel_previsao_realizado.html
@@ -1,0 +1,207 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="flex items-center mb-6">
+    <a href="{{ url_for('relatorios') }}" class="text-gray-500 hover:text-gray-700">
+        <i data-lucide="arrow-left-circle" class="w-8 h-8"></i>
+    </a>
+    <h2 class="text-2xl font-bold text-gray-800 ml-4">Relatório: Previsão x Realizado</h2>
+</div>
+
+<div class="bg-white p-6 rounded-lg shadow-md border">
+    <div class="grid grid-cols-1 md:grid-cols-3 lg:grid-cols-5 gap-4 items-end">
+        <div>
+            <label class="text-sm font-medium">Ano</label>
+            <select id="filter-ano" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm text-sm">
+                {% for ano in anos_disponiveis %}
+                    <option value="{{ ano }}" {% if ano == ano_default %}selected{% endif %}>{{ ano }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="relative">
+            <label class="text-sm font-medium">Mês</label>
+            <div class="mt-1">
+                <button type="button" id="mes-dropdown-btn" class="multiselect-button">
+                    <span id="mes-selected-text">{{ meses|length }} selecionados</span>
+                    <i data-lucide="chevron-down" class="h-4 w-4 opacity-50"></i>
+                </button>
+                <div id="mes-dropdown" class="multiselect-dropdown hidden shadow-lg">
+                    {% for mes in meses %}
+                    <label class="flex items-center text-sm">
+                        <input type="checkbox" class="mes-checkbox h-4 w-4 rounded border-gray-300" value="{{ mes[0] }}" checked>
+                        <span class="ml-2">{{ mes[1] }}</span>
+                    </label>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+        <div>
+            <label class="text-sm font-medium">Tipo</label>
+            <select id="filter-tipo" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm text-sm">
+                <option value="receita">Receita</option>
+                <option value="despesa">Despesa</option>
+            </select>
+        </div>
+        <div>
+            <label class="text-sm font-medium">Cenário</label>
+            <select id="filter-cenario" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm text-sm">
+                {% for c in cenarios %}
+                    <option value="{{ c.seq_cenario }}">{{ c.nom_cenario }}</option>
+                {% endfor %}
+            </select>
+        </div>
+        <div class="relative">
+            <label class="text-sm font-medium">Qualificadores</label>
+            <div class="mt-1">
+                <button type="button" id="qualificador-dropdown-btn" class="multiselect-button">
+                    <span id="qualificador-selected-text">{{ qualificadores|length }} selecionados</span>
+                    <i data-lucide="chevron-down" class="h-4 w-4 opacity-50"></i>
+                </button>
+                <div id="qualificador-dropdown" class="multiselect-dropdown hidden shadow-lg max-h-60 overflow-y-auto">
+                    {% for q in qualificadores %}
+                    <label class="flex items-center text-sm">
+                        <input type="checkbox" class="qualificador-checkbox h-4 w-4 rounded border-gray-300" value="{{ q.seq_qualificador }}" checked>
+                        <span class="ml-2">{{ q.dsc_qualificador }}</span>
+                    </label>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="mt-6">
+    <h3 class="text-lg font-semibold text-gray-800 mb-4">Resultados Consolidados</h3>
+    <div class="overflow-x-auto">
+        <table class="w-full text-left">
+            <thead class="bg-gray-100">
+                <tr>
+                    <th class="p-3">Descrição</th>
+                    <th class="p-3 text-right">Previsão Inicial</th>
+                    <th class="p-3 text-right">Previsão Final</th>
+                    <th class="p-3 text-right">Realizado</th>
+                </tr>
+            </thead>
+            <tbody id="result-table-body"></tbody>
+        </table>
+    </div>
+</div>
+
+<div class="mt-8">
+    <h3 class="text-lg font-semibold text-gray-800 mb-4">Análise Gráfica</h3>
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div class="p-4 border rounded-lg"><canvas id="evolucao-chart"></canvas></div>
+        <div class="p-4 border rounded-lg"><canvas id="diferenca-chart"></canvas></div>
+    </div>
+</div>
+
+<style>
+.multiselect-button {
+    background-color: white;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    padding: 0.5rem 0.75rem;
+    width: 100%;
+    text-align: left;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+.multiselect-dropdown {
+    position: absolute;
+    background-color: white;
+    border: 1px solid #d1d5db;
+    border-radius: 0.375rem;
+    width: 100%;
+    z-index: 10;
+    margin-top: 0.25rem;
+    max-height: 200px;
+    overflow-y: auto;
+}
+.multiselect-dropdown label { display: block; padding: 0.5rem 0.75rem; cursor: pointer; }
+.multiselect-dropdown label:hover { background-color: #f3f4f6; }
+</style>
+
+<script>
+document.addEventListener('DOMContentLoaded', () => {
+    function getSelected(selector) {
+        return Array.from(document.querySelectorAll(selector + ':checked')).map(cb => cb.value);
+    }
+    function updateMultiselectText(selector, textElemId) {
+        const selected = getSelected(selector);
+        const textElem = document.getElementById(textElemId);
+        if(selected.length === 0) textElem.textContent = 'Selecione';
+        else if (selected.length === 1) textElem.textContent = document.querySelector(selector + ':checked').parentElement.querySelector('span').textContent;
+        else textElem.textContent = selected.length + ' selecionados';
+    }
+    function setupDropdown(btnId, dropdownId, checkboxSelector, textElemId) {
+        const btn = document.getElementById(btnId);
+        const dropdown = document.getElementById(dropdownId);
+        btn.addEventListener('click', e => { e.stopPropagation(); dropdown.classList.toggle('hidden');});
+        document.addEventListener('click', e => { if(!dropdown.contains(e.target) && !btn.contains(e.target)) dropdown.classList.add('hidden'); });
+        document.querySelectorAll(checkboxSelector).forEach(cb => cb.addEventListener('change', () => { updateMultiselectText(checkboxSelector, textElemId); fetchData(); }));
+        updateMultiselectText(checkboxSelector, textElemId);
+    }
+    setupDropdown('mes-dropdown-btn', 'mes-dropdown', '.mes-checkbox', 'mes-selected-text');
+    setupDropdown('qualificador-dropdown-btn', 'qualificador-dropdown', '.qualificador-checkbox', 'qualificador-selected-text');
+
+    document.getElementById('filter-ano').addEventListener('change', fetchData);
+    document.getElementById('filter-tipo').addEventListener('change', fetchData);
+    document.getElementById('filter-cenario').addEventListener('change', fetchData);
+
+    let evolucaoChart = null;
+    let diffChart = null;
+
+    function renderTable(data) {
+        const tbody = document.getElementById('result-table-body');
+        tbody.innerHTML = '';
+        data.forEach(row => {
+            const tr = document.createElement('tr');
+            tr.className = 'border-b';
+            tr.innerHTML = `<td class="p-3 font-semibold text-gray-700">${row.descricao}</td>` +
+                           `<td class="p-3 text-right font-mono">${row.previsao_inicial}</td>` +
+                           `<td class="p-3 text-right font-mono">${row.previsao_final}</td>` +
+                           `<td class="p-3 text-right font-mono font-bold">${row.realizado}</td>`;
+            tbody.appendChild(tr);
+        });
+    }
+    function renderEvolucaoChart(labels, previsao, realizado) {
+        const ctx = document.getElementById('evolucao-chart').getContext('2d');
+        if (evolucaoChart) evolucaoChart.destroy();
+        evolucaoChart = new Chart(ctx, {
+            type: 'line',
+            data: { labels, datasets: [
+                { label: 'Previsão (em Bi)', data: previsao, borderColor: 'rgb(54,162,235)', tension:0.1 },
+                { label: 'Realizado (em Bi)', data: realizado, borderColor: 'rgb(75,192,192)', tension:0.1 }
+            ]},
+            options: { responsive: true, plugins: { title: { display: true, text: 'Evolução Mensal Consolidada (Valores em Bilhões)' } } }
+        });
+    }
+    function renderDiffChart(labels, diffFinal, diffInicial) {
+        const ctx = document.getElementById('diferenca-chart').getContext('2d');
+        if (diffChart) diffChart.destroy();
+        diffChart = new Chart(ctx, {
+            type: 'line',
+            data: { labels, datasets: [
+                { label:'Realizado vs Prev. Final (Bi)', data: diffFinal, borderColor:'rgb(255,99,132)', tension:0.1 },
+                { label:'Realizado vs Prev. Inicial (Bi)', data: diffInicial, borderColor:'rgb(255,159,64)', tension:0.1 }
+            ]},
+            options: { responsive:true, plugins:{ title:{ display:true, text:'Evolução Anual da Diferença (Realizado vs Previsão)' } } }
+        });
+    }
+    async function fetchData() {
+        const ano = document.getElementById('filter-ano').value;
+        const tipo = document.getElementById('filter-tipo').value;
+        const cenario = document.getElementById('filter-cenario').value;
+        const meses = getSelected('.mes-checkbox').join(',');
+        const qualificadores = getSelected('.qualificador-checkbox').join(',');
+        const params = new URLSearchParams({ano, tipo, cenario, meses, qualificadores});
+        const response = await fetch(`{{ url_for('relatorio_previsao_realizado_data') }}?${params.toString()}`);
+        const json = await response.json();
+        renderTable(json.tabela);
+        renderEvolucaoChart(json.evolucao.labels, json.evolucao.previsao, json.evolucao.realizado);
+        renderDiffChart(json.diferenca.labels, json.diferenca.final, json.diferenca.inicial);
+    }
+    fetchData();
+});
+</script>
+{% endblock %}

--- a/templates/relatorios.html
+++ b/templates/relatorios.html
@@ -41,5 +41,14 @@
             <p class="text-xs text-gray-500 mt-1">Compara ingressos entre diferentes períodos</p>
         </div>
     </a>
+    <a href="{{ url_for('relatorio_previsao_realizado') }}" class="nav-card">
+        <div class="h-full bg-white p-6 rounded-lg shadow-sm border border-gray-200 hover:shadow-lg hover:border-blue-400 transition-all text-center flex flex-col justify-center items-center">
+            <div class="mx-auto flex items-center justify-center h-16 w-16 rounded-full" style="background-color: #E7F1FA;">
+                <i data-lucide="target" style="color: var(--sefaz-primary-blue);"></i>
+            </div>
+            <p class="mt-4 font-semibold text-gray-700 h-12 flex items-center justify-center">Previsão x Realizado</p>
+            <p class="text-xs text-gray-500 mt-1">Comparativo entre previsão e valores realizados</p>
+        </div>
+    </a>
 </div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- expand Cenario model with audit fields
- add interactive Previsão x Realizado report with filters and charts
- seed base scenario with user information

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893bac5a068832abc7144229a892562